### PR TITLE
feat!: update API operations results to include SplunkACSResponse

### DIFF
--- a/.github/workflows/pre-pr.yml
+++ b/.github/workflows/pre-pr.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/index/create_index.go
+++ b/examples/index/create_index.go
@@ -25,9 +25,9 @@ func main() {
 		MaxDataSizeMb:  0,
 	}
 
-	indexCreateResp, res, err := acsClient.CreateIndex(indexCreateRequest)
+	indexCreateResp, apiRes, err := acsClient.CreateIndex(indexCreateRequest)
 	if err != nil {
-		fmt.Printf("encountered unexpected error. Response code: %d\n", res.StatusCode)
+		fmt.Printf("encountered unexpected error. Response code: %d\n", apiRes.StatusCode)
 		log.Fatal(err)
 	}
 	fmt.Printf("name: '%s' totalEventCount: '%s'\n", indexCreateResp.Name, indexCreateResp.TotalEventCount)

--- a/examples/index/delete_index.go
+++ b/examples/index/delete_index.go
@@ -18,10 +18,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	getIndexResp, res, err := acsClient.DeleteIndex(*IndexNameFlag)
+	getIndexResp, apiRes, err := acsClient.DeleteIndex(*IndexNameFlag)
 	if err != nil {
-		fmt.Printf("encountered unexpected error. Response code: %d\n", res.StatusCode)
+		fmt.Printf("encountered unexpected error. Response code: %d\n", apiRes.StatusCode)
 		log.Fatal(err)
 	}
-	fmt.Printf("status: '%d' resp: '%s'\n", res.StatusCode, getIndexResp)
+	fmt.Printf("status: '%d' resp: '%s'\n", apiRes.StatusCode, getIndexResp)
 }

--- a/examples/index/get_index.go
+++ b/examples/index/get_index.go
@@ -18,9 +18,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	getIndexResp, res, err := acsClient.GetIndex(*IndexNameFlag)
+	getIndexResp, apiRes, err := acsClient.GetIndex(*IndexNameFlag)
 	if err != nil {
-		fmt.Printf("encountered unexpected error. Response code: %d\n", res.StatusCode)
+		fmt.Printf("encountered unexpected error. Response code: %d\n", apiRes.StatusCode)
 		log.Fatal(err)
 	}
 	fmt.Printf("name: '%s' totalEventCount: '%s'\n", getIndexResp.Name, getIndexResp.TotalEventCount)

--- a/examples/index/list_indexes.go
+++ b/examples/index/list_indexes.go
@@ -18,9 +18,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	listIndexResp, res, err := acsClient.ListIndexes()
+	listIndexResp, apiRes, err := acsClient.ListIndexes()
 	if err != nil {
-		fmt.Printf("encountered unexpected error. Response code: %d\n", res.StatusCode)
+		fmt.Printf("encountered unexpected error. Response code: %d\n", apiRes.StatusCode)
 		log.Fatal(err)
 	}
 	for _, index := range *listIndexResp {

--- a/examples/index/update_index.go
+++ b/examples/index/update_index.go
@@ -23,9 +23,9 @@ func main() {
 		MaxDataSizeMb:  0,
 	}
 
-	getIndexResp, res, err := acsClient.UpdateIndex(*IndexNameFlag, indexUpdateRequest)
+	getIndexResp, apiRes, err := acsClient.UpdateIndex(*IndexNameFlag, indexUpdateRequest)
 	if err != nil {
-		fmt.Printf("encountered unexpected error. Response code: %d\n", res.StatusCode)
+		fmt.Printf("encountered unexpected error. Response code: %d\n", apiRes.StatusCode)
 		log.Fatal(err)
 	}
 	fmt.Printf("name: '%s' totalEventCount: '%s, searchableDays: '%s'\n", getIndexResp.Name, getIndexResp.TotalEventCount, getIndexResp.SearchableDays)

--- a/splunkacs/api_op_create_hec_tokens.go
+++ b/splunkacs/api_op_create_hec_tokens.go
@@ -27,7 +27,7 @@ type HttpEventCollectorCreateResponseSpec struct {
 	Name string `json:"name"`
 }
 
-func (c *SplunkAcsClient) CreateHecToken(hecCreateRequest HttpEventCollectorCreateRequest) (*HttpEventCollectorCreateResponse, *http.Response, error) {
+func (c *SplunkAcsClient) CreateHecToken(hecCreateRequest HttpEventCollectorCreateRequest) (*HttpEventCollectorCreateResponse, *SplunkACSResponse, error) {
 	reqBody, err := json.Marshal(hecCreateRequest)
 	if err != nil {
 		return nil, nil, err
@@ -38,20 +38,20 @@ func (c *SplunkAcsClient) CreateHecToken(hecCreateRequest HttpEventCollectorCrea
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while creating HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while creating HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := HttpEventCollectorCreateResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return &result, apiRes.HttpResponse, err
+		return &result, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_create_index.go
+++ b/splunkacs/api_op_create_index.go
@@ -20,7 +20,7 @@ type IndexCreateResponse struct {
 	Index
 }
 
-func (c *SplunkAcsClient) CreateIndex(indexRequest IndexCreateRequest) (*IndexCreateResponse, *http.Response, error) {
+func (c *SplunkAcsClient) CreateIndex(indexRequest IndexCreateRequest) (*IndexCreateResponse, *SplunkACSResponse, error) {
 	reqBody, err := json.Marshal(indexRequest)
 	if err != nil {
 		return nil, nil, err
@@ -31,20 +31,20 @@ func (c *SplunkAcsClient) CreateIndex(indexRequest IndexCreateRequest) (*IndexCr
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while creating index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while creating index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := IndexCreateResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return &result, apiRes.HttpResponse, err
+		return &result, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_delete_hec_token.go
+++ b/splunkacs/api_op_delete_hec_token.go
@@ -10,27 +10,27 @@ type HttpEventCollectorDeleteResponse struct {
 	Body string
 }
 
-func (c *SplunkAcsClient) DeleteHecToken(hecName string) (*HttpEventCollectorDeleteResponse, *http.Response, error) {
+func (c *SplunkAcsClient) DeleteHecToken(hecName string) (*HttpEventCollectorDeleteResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/adminconfig/v2/inputs/http-event-collectors/%s", c.Url, hecName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode == http.StatusNotFound {
-		return nil, apiRes.HttpResponse, fmt.Errorf("HEC not found. body: '%s'", apiRes.Body)
+		return nil, apiRes, fmt.Errorf("HEC not found. body: '%s'", apiRes.Body)
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while deleting HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while deleting HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := HttpEventCollectorDeleteResponse{}
 	result.Body = string(apiRes.Body)
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_delete_index.go
+++ b/splunkacs/api_op_delete_index.go
@@ -12,27 +12,27 @@ type IndexDeleteResponse struct {
 	Body string
 }
 
-func (c *SplunkAcsClient) DeleteIndex(indexName string) (*IndexDeleteResponse, *http.Response, error) {
+func (c *SplunkAcsClient) DeleteIndex(indexName string) (*IndexDeleteResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/adminconfig/v2/indexes/%s", c.Url, indexName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode == http.StatusNotFound {
-		return nil, apiRes.HttpResponse, fmt.Errorf("index not found. body: '%s'", apiRes.Body)
+		return nil, apiRes, fmt.Errorf("index not found. body: '%s'", apiRes.Body)
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while deleting index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while deleting index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := IndexDeleteResponse{}
 	result.Body = string(apiRes.Body)
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_get_hec_token.go
+++ b/splunkacs/api_op_get_hec_token.go
@@ -11,30 +11,30 @@ type HttpEventCollectorGetResponse struct {
 	HttpEventCollector HttpEventCollectorToken `json:"http-event-collector"`
 }
 
-func (c *SplunkAcsClient) GetHecToken(hecName string) (*HttpEventCollectorGetResponse, *http.Response, error) {
+func (c *SplunkAcsClient) GetHecToken(hecName string) (*HttpEventCollectorGetResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/adminconfig/v2/inputs/http-event-collectors/%s", c.Url, hecName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode == http.StatusNotFound {
-		return nil, apiRes.HttpResponse, fmt.Errorf("HEC not found. body: '%s'", apiRes.Body)
+		return nil, apiRes, fmt.Errorf("HEC not found. body: '%s'", apiRes.Body)
 	}
 
 	if apiRes.StatusCode != http.StatusOK {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while getting HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while getting HEC Token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := HttpEventCollectorGetResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_get_index.go
+++ b/splunkacs/api_op_get_index.go
@@ -12,31 +12,31 @@ type IndexGetResponse struct {
 	Index
 }
 
-func (c *SplunkAcsClient) GetIndex(indexName string) (*IndexGetResponse, *http.Response, error) {
+func (c *SplunkAcsClient) GetIndex(indexName string) (*IndexGetResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/adminconfig/v2/indexes/%s", c.Url, indexName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode == http.StatusNotFound {
-		return nil, apiRes.HttpResponse, fmt.Errorf("Index not found. body: '%s'", apiRes.Body)
+		return nil, apiRes, fmt.Errorf("Index not found. body: '%s'", apiRes.Body)
 	}
 
 	if apiRes.StatusCode != http.StatusOK {
 		log.Printf("failed to unmarshal response body: %s", string(apiRes.Body))
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while getting index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while getting index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := IndexGetResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_list_hec_tokens.go
+++ b/splunkacs/api_op_list_hec_tokens.go
@@ -13,26 +13,26 @@ type HttpEventCollectorListResponse struct {
 
 // Lists all HECs
 // TODO check if count=0 is sufficent or we need to use pagination to go beyond 100 results
-func (c *SplunkAcsClient) ListHecTokens() (*HttpEventCollectorListResponse, *http.Response, error) {
+func (c *SplunkAcsClient) ListHecTokens() (*HttpEventCollectorListResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/adminconfig/v2/inputs/http-event-collectors?count=0", c.Url), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusOK {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while listing HEC Tokens. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while listing HEC Tokens. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := HttpEventCollectorListResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_list_indexes.go
+++ b/splunkacs/api_op_list_indexes.go
@@ -11,26 +11,26 @@ type IndexListResponse []Index
 
 // Lists all Indexes
 // TODO introduce pagination
-func (c *SplunkAcsClient) ListIndexes() (*IndexListResponse, *http.Response, error) {
+func (c *SplunkAcsClient) ListIndexes() (*IndexListResponse, *SplunkACSResponse, error) {
 	httpReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/adminconfig/v2/indexes?count=0", c.Url), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusOK {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while listing indexes. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while listing indexes. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := IndexListResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_update_hec_token.go
+++ b/splunkacs/api_op_update_hec_token.go
@@ -20,7 +20,7 @@ type HttpEventCollectorUpdateResponse struct {
 	Code string `json:"code"`
 }
 
-func (c *SplunkAcsClient) UpdateHecToken(hecName string, hecUpdateRequest HttpEventCollectorUpdateRequest) (*HttpEventCollectorUpdateResponse, *http.Response, error) {
+func (c *SplunkAcsClient) UpdateHecToken(hecName string, hecUpdateRequest HttpEventCollectorUpdateRequest) (*HttpEventCollectorUpdateResponse, *SplunkACSResponse, error) {
 	reqBody, err := json.Marshal(hecUpdateRequest)
 	if err != nil {
 		return nil, nil, err
@@ -31,21 +31,21 @@ func (c *SplunkAcsClient) UpdateHecToken(hecName string, hecUpdateRequest HttpEv
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while updating HEC token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while updating HEC token. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := HttpEventCollectorUpdateResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
 		log.Printf("failed to unmarshal response body: %s", string(apiRes.Body))
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/api_op_update_index.go
+++ b/splunkacs/api_op_update_index.go
@@ -19,7 +19,7 @@ type IndexUpdateResponse struct {
 	Index
 }
 
-func (c *SplunkAcsClient) UpdateIndex(indexName string, indexUpdateRequest IndexUpdateRequest) (*IndexUpdateResponse, *http.Response, error) {
+func (c *SplunkAcsClient) UpdateIndex(indexName string, indexUpdateRequest IndexUpdateRequest) (*IndexUpdateResponse, *SplunkACSResponse, error) {
 	reqBody, err := json.Marshal(indexUpdateRequest)
 	if err != nil {
 		return nil, nil, err
@@ -30,21 +30,21 @@ func (c *SplunkAcsClient) UpdateIndex(indexName string, indexUpdateRequest Index
 		return nil, nil, err
 	}
 
-	apiRes, err := c.doRequest(NewSplunkApiRequest(httpReq))
+	apiRes, err := c.doRequest(NewSplunkACSRequest(httpReq))
 	if err != nil {
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
 	if apiRes.StatusCode != http.StatusAccepted {
-		return nil, apiRes.HttpResponse, fmt.Errorf("unexpected response while updating index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
+		return nil, apiRes, fmt.Errorf("unexpected response while updating index. status: %d, body: %s", apiRes.StatusCode, apiRes.Body)
 	}
 
 	result := IndexUpdateResponse{}
 	err = json.Unmarshal(apiRes.Body, &result)
 	if err != nil {
 		log.Printf("failed to unmarshal response body: %s", string(apiRes.Body))
-		return nil, apiRes.HttpResponse, err
+		return nil, apiRes, err
 	}
 
-	return &result, apiRes.HttpResponse, nil
+	return &result, apiRes, nil
 }

--- a/splunkacs/client.go
+++ b/splunkacs/client.go
@@ -32,7 +32,7 @@ func (c *SplunkAcsClient) executeHttpRequest(req *http.Request) (*http.Response,
 	return res, nil
 }
 
-func (c *SplunkAcsClient) doRequest(apiRequest *SplunkApiRequest) (*SplunkApiResponse, error) {
+func (c *SplunkAcsClient) doRequest(apiRequest *SplunkACSRequest) (*SplunkACSResponse, error) {
 
 	token := c.Token
 	apiRequest.HttpRequest.Header.Set("Authorization", "Bearer "+token)
@@ -81,7 +81,7 @@ func (c *SplunkAcsClient) doRequest(apiRequest *SplunkApiRequest) (*SplunkApiRes
 				continue
 			}
 		}
-		return NewSplunkApiResponse(res)
+		return NewSplunkACSResponse(res)
 	}
 	return nil, fmt.Errorf("failed to get a valid response after %d retries", apiRequest.RetryLimit)
 }

--- a/splunkacs/models.go
+++ b/splunkacs/models.go
@@ -31,34 +31,34 @@ type Index struct {
 	TotalRawSizeMb  string `json:"totalRawSizeMB,omitempty"`
 }
 
-type SplunkApiRequest struct {
+type SplunkACSRequest struct {
 	HttpRequest *http.Request
 	RetryLimit  int
 }
 
-func NewSplunkApiRequest(httpRequest *http.Request) *SplunkApiRequest {
-	return &SplunkApiRequest{
+func NewSplunkACSRequest(httpRequest *http.Request) *SplunkACSRequest {
+	return &SplunkACSRequest{
 		HttpRequest: httpRequest,
 		RetryLimit:  4, // Arbitrary magic value
 	}
 }
 
-type SplunkApiResponse struct {
+type SplunkACSResponse struct {
 	HttpResponse *http.Response
 	Body         []byte
 	StatusCode   int
 }
 
-func NewSplunkApiResponse(httpResponse *http.Response) (*SplunkApiResponse, error) {
+func NewSplunkACSResponse(httpResponse *http.Response) (*SplunkACSResponse, error) {
 	defer httpResponse.Body.Close()
 	body, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
-		return &SplunkApiResponse{
+		return &SplunkACSResponse{
 			HttpResponse: httpResponse,
 		}, nil
 	}
 
-	return &SplunkApiResponse{
+	return &SplunkACSResponse{
 		HttpResponse: httpResponse,
 		Body:         body,
 		StatusCode:   httpResponse.StatusCode,


### PR DESCRIPTION
Until now the results of each API operation also included the underlying `HttpResponse` in order to allow the downstream consumers to adjust their operation based on additional parameters such as `StatusCode` and headers. This is not ideal and I would like to decouple the client API results from the http  responses. The plan is that any additional metadata that might be required will be provided in the new `SplunkACSResponse` struct. 
For now that still includes the `HttpResponse` for easy migration and backward compatibility.